### PR TITLE
chore: add commitizen configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # generator-ca
+[![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 
 This generator can be used to assist with build projects that use React by scaffoling out common features and components.
 
@@ -23,3 +24,11 @@ Then generate your new component:
 ```bash
 yo ca:component
 ```
+
+
+## Contributing
+
+This project supports `commitizen`. You can use `npm run commit` to run the local instance of `commitizen` or `git cz` if you have it installed globally.
+
+Alternatively, if you are simply using `git commit`, you must follow this format:
+`git commit -m "<type>: <subject>"`

--- a/package.json
+++ b/package.json
@@ -33,7 +33,11 @@
     "gulp-mocha": "^3.0.1",
     "gulp-plumber": "^1.0.0",
     "gulp-nsp": "^2.1.0",
-    "semantic-release": "^4.3.5"
+    "semantic-release": "^4.3.5",
+    "commitizen": "^2.8.6",
+    "cz-conventional-changelog": "^1.2.0",
+    "husky": "^0.11.9",
+    "validate-commit-msg": "^2.8.2"
   },
   "eslintConfig": {
     "extends": "xo-space",
@@ -43,12 +47,22 @@
   },
   "repository": {
     "type": "git",
-    "url": "https:undefined.git"
+    "url": "https://github.com/CAAPIM/generator-ca.git"
   },
   "scripts": {
     "prepublish": "gulp prepublish",
     "test": "gulp",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post",
+    "commit": "git-cz",
+    "commitmsg": "validate-commit-msg"
+  },
+  "config": {
+    "validate-commit-msg": {
+      "types": "conventional-commit-types"
+    },
+    "commitizen": {
+      "path": "cz-conventional-changelog"
+    }
   },
   "license": "Apache-2.0"
 }


### PR DESCRIPTION
This Commit adds `commitizen`, `validate-commit-msg` and `cz-conventional-changelog` functionality to this repo, as per https://rally1.rallydev.com/#/63515825210ud/detail/userstory/78741891276

Commit messages for this project will now have to be structured in this format:
`git commit -m "<type>: <subject>"`

e.g. `git commit -m "chore: add commitizen adapter"`

CC: @alebiavati @shanedasilva @bevanhunt